### PR TITLE
Update lambda runtime to supported nodejs version.

### DIFF
--- a/sam-hello-world-1/template.yml
+++ b/sam-hello-world-1/template.yml
@@ -6,4 +6,4 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x

--- a/sam-hello-world-2/template.yml
+++ b/sam-hello-world-2/template.yml
@@ -5,7 +5,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x
       Events:
         HelloWorldApi:
           Type: Api

--- a/sam-hello-world-3/template.yml
+++ b/sam-hello-world-3/template.yml
@@ -5,7 +5,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs14.x
       Events:
         HelloWorldApi:
           Type: Api


### PR DESCRIPTION
Thank you for this helpful example project. 

This PR fixes this error:

> The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions. 

By updating to the latest nodejs version according to [these AWS docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html).